### PR TITLE
Clean up api

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ redis-server
 
 #### Require raccoon in your node server:
 ``` js
-var raccoon = require('raccoon').raccoon();
+var raccoon = require('raccoon');
 ```
 
 #### Add in ratings:

--- a/lib/algorithms.js
+++ b/lib/algorithms.js
@@ -1,6 +1,6 @@
 // var redis = require("redis"),
     var async = require('async'),
-    config = require('./config.js').config(),
+    config = require('./config.js'),
     _ = require('underscore');
 
   // the jaccard coefficient outputs an objective measurement of the similar between two objects. in this case, two users. the coefficient

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,6 +1,7 @@
-exports.config = function(){
+(function() {
+  var Config;
 
-  return {
+  Config = {
     nearestNeighbors: 5,
     className: 'movie',
     numOfRecsStore: 30,
@@ -16,4 +17,6 @@ exports.config = function(){
     flushDBsOnStart: true,
     localSetup: true
   };
-};
+
+  module.exports = Config;
+}).call(this);

--- a/lib/globalreq.js
+++ b/lib/globalreq.js
@@ -1,5 +1,5 @@
 var redis = require("redis"),
-    config = require('./config.js').config();
+    config = require('./config.js');
 
 
 module.exports = function() {

--- a/lib/input.js
+++ b/lib/input.js
@@ -1,6 +1,5 @@
-exports.input = function(){
-
-  var config = require('./config.js').config(),
+(function() {
+  var config = require('./config.js'),
       algo = require('./algorithms.js');
 
   var updateSequence = function(userId, itemId, callback){
@@ -13,7 +12,7 @@ exports.input = function(){
     });
   };
 
-  return {
+  var Input = {
     liked: function(userId, itemId, callback){
       client.sismember([config.className, itemId, 'liked'].join(":"), userId, function(err, results){
         if (results === 0){
@@ -39,4 +38,6 @@ exports.input = function(){
       });
     }
   };
-};
+
+  module.exports = Input;
+}).call(this);

--- a/lib/raccoon.js
+++ b/lib/raccoon.js
@@ -1,12 +1,11 @@
-exports.raccoon = function(){
-
-  var config = require('./config.js').config(),
+(function() {
+  var config = require('./config.js'),
       algo = require('./algorithms.js'),
-      input = require('./input.js').input(),
-      stat = require('./stat.js').stat();
+      input = require('./input.js'),
+      stat = require('./stat.js');
       require('./globalreq.js')();
 
-  return {
+  var Raccoon = {
     config: config,
     input: input,
     stat: stat,
@@ -29,4 +28,6 @@ exports.raccoon = function(){
     allDislikedFor: stat.allDislikedFor,
     allWatchedFor: stat.allWatchedFor
   };
-};
+
+  module.exports = Raccoon;
+}).call(this);

--- a/lib/stat.js
+++ b/lib/stat.js
@@ -1,8 +1,7 @@
-  exports.stat = function(){
+(function() {
+  var config = require('./config.js');
 
-  var config = require('./config.js').config();
-
-  return {
+  var Stat = {
     recommendFor: function(userId, numberOfRecs, callback){
       client.zrevrange([config.className, userId, 'recommendedSet'].join(":"), 0, numberOfRecs, function(err, results){
         callback(results);
@@ -82,4 +81,6 @@
       });
     }
   };
-};
+
+  module.exports = Stat;
+}).call(this);

--- a/test/testRaccoon.js
+++ b/test/testRaccoon.js
@@ -11,9 +11,9 @@ chai.use(require('sinon-chai'));
 //     // options are passed as an argument object to the require statement
 //    "pattern": "../lib/"
 //  });
-var config = require('../lib/config.js').config();
+var config = require('../lib/config.js');
     config.localSetup = true;
-var raccoon = require('../lib/raccoon.js').raccoon();
+var raccoon = require('../lib/raccoon.js');
 
 var redis = require("redis"),
     client = redis.createClient();


### PR DESCRIPTION
The redundant .raccoon(), .config(), etc. on the require statements are now no longer necessary. For example:

```
var racooon = require('raccoon').raccoon();
```

becomes

```
var raccoon = require('raccoon');
```

All tests still pass and the documentation has been updated to reflect the change.
