### PR TITLE
Set remote Redis port by process.env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ remoteMongoDbURL: process.env.MONGO_HOSTAUTH, // remote mongo DB url
   // this should include all auth info
 localRedisPort: 6379, // local redis port
 localRedisURL: '127.0.0.1', // local redis url
-remoteRedisPort: 12000, // remove redis port
+remoteRedisPort: process.env.REDIS_PORT || 12000, // remote redis port
 remoteRedisURL: process.env.REDIS_HOST, // remote redis url
 remoteRedisAuth: process.env.REDIS_AUTH, // remote redis auth
 flushDBsOnStart: true, // whether you want to flush the db's on first startup

--- a/lib/config.js
+++ b/lib/config.js
@@ -11,7 +11,7 @@
     remoteMongoDbURL: process.env.MONGO_HOSTAUTH,
     localRedisPort: 6379,
     localRedisURL: '127.0.0.1',
-    remoteRedisPort: 12000,
+    remoteRedisPort: process.env.REDIS_PORT || 12000,
     remoteRedisURL: process.env.REDIS_HOST,
     remoteRedisAuth: process.env.REDIS_AUTH,
     flushDBsOnStart: true,


### PR DESCRIPTION
Much easier way to customize the remote Redis port, so I can deploy this on Heroku.
