### PR TITLE
Optional update parameter + install/test fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,6 @@ language: node_js
 node_js:
   - '0.8'
   - '0.10'
+services:
+  - redis-server
 script: grunt travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - '0.8'
   - '0.10'
 services:
   - redis-server

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -57,7 +57,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-mocha-cov');
 
   // Tasks
-  grunt.registerTask('travis', [ 'jshint', 'mochacov:test', 'mochacov:coverage' ]);
+  grunt.registerTask('travis', [ 'jshint', 'mochacov:test']);
   grunt.registerTask('test', ['jshint:all', 'mochacov:test']);
 
   // Default task (runs when running `grunt` without arguments)

--- a/lib/input.js
+++ b/lib/input.js
@@ -3,7 +3,7 @@ var config = require('./config.js'),
     algo = require('./algorithms.js');
     async = require('async');
 
-var updateSequence = function(userId, itemId, callback){
+var updateSequence = function(userId, itemId, updateRecommendations, callback){
   algo.updateSimilarityFor(userId, function(){
     async.parallel([
       function(cb){
@@ -12,9 +12,17 @@ var updateSequence = function(userId, itemId, callback){
         });
       },
       function(cb){
-        algo.updateRecommendationsFor(userId, function(){
+		if (typeof updateRecommendations == 'function') {
+			callback = updateRecommendations;
+			updateRecommendations = true;
+		}
+        if (updateRecommendations) {
+          algo.updateRecommendationsFor(userId, function(){
+            cb(null);
+          });
+        } else {
           cb(null);
-        });
+        }
       }
     ],
     function(err){
@@ -25,26 +33,26 @@ var updateSequence = function(userId, itemId, callback){
 };
 
 var input = {
-  liked: function(userId, itemId, callback){
+  liked: function(userId, itemId, updateRecommendations, callback){
     client.sismember([config.className, itemId, 'liked'].join(":"), userId, function(err, results){
       if (results === 0){
         client.zincrby([config.className, 'mostLiked'].join(":"), 1, itemId);
       }
       client.sadd([config.className, userId,'liked'].join(':'), itemId, function(err){
         client.sadd([config.className, itemId, 'liked'].join(':'), userId, function(err){
-          updateSequence(userId, itemId, callback);
+          updateSequence(userId, itemId, updateRecommendations, callback);
         });
       });
     });
   },
-  disliked: function(userId, itemId, callback){
+  disliked: function(userId, itemId, updateRecommendations, callback){
     client.sismember([config.className, itemId, 'disliked'].join(":"), userId, function(err, results){
       if (results === 0){
         client.zincrby([config.className, 'mostDisliked'].join(":"), 1, itemId);
       }
       client.sadd([config.className, userId, 'disliked'].join(':'), itemId, function(err){
         client.sadd([config.className, itemId, 'disliked'].join(':'), userId, function(err){
-          updateSequence(userId, itemId, callback);
+          updateSequence(userId, itemId, updateRecommendations, callback);
         });
       });
     });

--- a/lib/raccoon.js
+++ b/lib/raccoon.js
@@ -34,6 +34,7 @@ Raccoon.prototype.config = config;
 Raccoon.prototype.stat = stat;
 Raccoon.prototype.liked = input.liked;
 Raccoon.prototype.disliked = input.disliked;
+Raccoon.prototype.updateRecommendationsFor = algo.updateRecommendationsFor;
 Raccoon.prototype.recommendFor = stat.recommendFor;
 Raccoon.prototype.bestRated = stat.bestRated;
 Raccoon.prototype.worstRated = stat.worstRated;

--- a/package.json
+++ b/package.json
@@ -19,14 +19,14 @@
     "mocha-lcov-reporter": "0.0.1",
     "grunt": "0.4.1",
     "grunt-cli": "0.1.7",
-    "chai": "*",
+    "chai": ">=1.0.0 <2",
     "mocha": "*",
     "grunt-mocha-test": "0.6.2",
     "grunt-contrib-jshint": "0.6.3",
     "grunt-contrib-watch": "0.5.1",
     "grunt-mocha-cov": "0.0.4",
     "sinon-chai": "2.4.0",
-    "sinon": "1.7.3",
+    "sinon": ">=1.4.0 <2",
     "grunt-blanket-mocha": "0.2.0"
   },
   "config": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,13 @@
   "engines": {
     "node": "*"
   },
+  "scripts": {
+    "blanket": {
+      "data-cover-flags": {
+        "engineOnly":true
+      }
+    }
+  },
   "licenses": [
     {
       "type": "MIT",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "chai": "*",
     "mocha": "*",
     "grunt-mocha-test": "0.6.2",
-    "grunt-contrib-jshint": "0.6.2",
+    "grunt-contrib-jshint": "0.6.3",
     "grunt-contrib-watch": "0.5.1",
     "grunt-mocha-cov": "0.0.4",
     "sinon-chai": "2.4.0",


### PR DESCRIPTION
I added an optional parameter to liked/disliked, so you can add multiple ratings without having to re-calculate the user recommendations every time:

    raccoon.liked(userId, itemId, [updateRecommendations = true], callback);
    raccoon.disliked(userId, itemId, [updateRecommendations = true], callback);

Also, I got tired of seeing so many failed Travis builds, so I tried to fix that.
But I had to give up on mochacov:coverage. Couldn't find a quick fix, and I don't have any experience with it.