### PR TITLE
Add to existing when creating temporary set

### DIFF
--- a/lib/algorithms.js
+++ b/lib/algorithms.js
@@ -173,7 +173,7 @@ exports.updateRecommendationsFor = function(userId, cb){
         // the callbacks. this will likely get refactored to use promises.
         async.each(setsToUnion,
           function(set, callback){
-            client.sunionstore(tempSet, set, function(err){
+            client.sunionstore(tempSet, set, tempSet, function(err){
               callback();
             });
           },


### PR DESCRIPTION
When creating a temporary set of items that the similar users have liked - add to the existing set, and not overwrite. At the moment, it will reflect the items just from one of the users.
