### PR TITLE
Add option to remove old rating when liking/disliking

### DIFF
--- a/lib/input.js
+++ b/lib/input.js
@@ -39,15 +39,37 @@ const changeRating = function(userId, itemId, options){
   }
 
   const removeRating = options.removeRating ? true : false;
+  const removeOldRating = options.removeOldRating ? true : false;
 
   const feelingItemSet = options.liked ? Key.itemLikedBySet(itemId) : Key.itemDislikedBySet(itemId);
   const feelingUserSet = options.liked ? Key.userLikedSet(userId) : Key.userDislikedSet(userId);
   const mostFeelingSet = options.liked ? Key.mostLiked() : Key.mostDisliked();
 
+  const feelingItemSetOpposite = options.liked ? Key.itemDislikedBySet(itemId) : Key.itemLikedBySet(itemId);
+  const feelingUserSetOpposite = options.liked ? Key.userDislikedSet(userId) : Key.userLikedSet(userId);
+  const mostFeelingSetOpposite = options.liked ? Key.mostDisliked() : Key.mostLiked();
+
   return new Promise((resolve, reject) => {
     Promise.resolve().then(() => {
-      // check if the rating is already stored
-      return client.sismemberAsync(feelingItemSet, userId);
+      if (removeOldRating) {
+        // check if opposite rating is already stored
+        return client.sismemberAsync(feelingItemSetOpposite, userId).then((result) => {
+          if (result > 0) {
+            // only remove opposite rating if it already exists
+            client.zincrby(mostFeelingSetOpposite, -1, itemId);
+            return client.sremAsync(feelingUserSetOpposite, itemId).then(() => {
+              return client.sremAsync(feelingItemSetOpposite, userId);
+            }).then(() => {
+              return client.sismemberAsync(feelingItemSet, userId);
+            });
+          } else {
+            return client.sismemberAsync(feelingItemSet, userId);
+          }
+        });
+      } else {
+        // check if the rating is already stored
+        return client.sismemberAsync(feelingItemSet, userId);
+      }
     }).then((result) => {
       // only increment the most feeling set if it doesn't already exist
       if (result === 0 && !removeRating) {
@@ -78,11 +100,13 @@ const changeRating = function(userId, itemId, options){
 
 const liked = function(userId, itemId, options = {}){
   options.liked = true;
+  options.removeOldRating = true;
   return changeRating(userId, itemId, options);
 };
 
 const disliked = function(userId, itemId, options = {}){
   options.liked = false;
+  options.removeOldRating = true;
   return changeRating(userId, itemId, options);
 };
 


### PR DESCRIPTION
Currently, liking/disliking does not trigger undisliked/unliked, leading to the same item present in both liked and disliked sets.